### PR TITLE
Made TFVC plugin to be compatible with 7.3 Sonar API

### DIFF
--- a/sonar-scm-tfvc-plugin/pom.xml
+++ b/sonar-scm-tfvc-plugin/pom.xml
@@ -32,7 +32,7 @@
   </issueManagement>
 
   <properties>
-    <sonar.buildVersion>5.0</sonar.buildVersion>
+    <sonar.buildVersion>6.7</sonar.buildVersion>
     <sonar.pluginName>TFVC</sonar.pluginName>
     <sonar.pluginClass>org.sonar.plugins.scm.tfs.TfsPlugin</sonar.pluginClass>
   </properties>
@@ -51,8 +51,13 @@
       <version>2.0.3</version>
       <scope>provided</scope>
     </dependency>
+	<dependency>
+	    <groupId>com.google.guava</groupId>
+	    <artifactId>guava</artifactId>
+	    <version>r05</version>
+	</dependency>
     <dependency>
-      <groupId>org.codehaus.sonar</groupId>
+      <groupId>org.sonarsource.sonarqube</groupId>
       <artifactId>sonar-plugin-api</artifactId>
       <version>${sonar.buildVersion}</version>
       <scope>provided</scope>
@@ -60,7 +65,7 @@
 
     <!-- unit tests -->
     <dependency>
-      <groupId>org.codehaus.sonar</groupId>
+      <groupId>org.sonarsource.sonarqube</groupId>
       <artifactId>sonar-testing-harness</artifactId>
       <version>${sonar.buildVersion}</version>
       <scope>test</scope>
@@ -77,6 +82,12 @@
       <version>1.1.3</version>
       <scope>test</scope>
     </dependency>
+	<dependency>
+	    <groupId>org.easytesting</groupId>
+	    <artifactId>fest-assert</artifactId>
+	    <version>1.4</version>
+	    <scope>test</scope>
+	</dependency>
 
   </dependencies>
 

--- a/sonar-scm-tfvc-plugin/src/main/java/org/sonar/plugins/scm/tfs/TfsConfiguration.java
+++ b/sonar-scm-tfvc-plugin/src/main/java/org/sonar/plugins/scm/tfs/TfsConfiguration.java
@@ -6,29 +6,29 @@
  */
 package org.sonar.plugins.scm.tfs;
 
-import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
-import org.sonar.api.BatchComponent;
 import org.sonar.api.CoreProperties;
 import org.sonar.api.PropertyType;
 import org.sonar.api.batch.InstantiationStrategy;
+import org.sonar.api.batch.ScannerSide;
+import org.sonar.api.config.Configuration;
 import org.sonar.api.config.PropertyDefinition;
-import org.sonar.api.config.Settings;
 import org.sonar.api.resources.Qualifiers;
 
 import java.util.List;
 
 @InstantiationStrategy(InstantiationStrategy.PER_BATCH)
-public class TfsConfiguration implements BatchComponent {
+@ScannerSide()
+public class TfsConfiguration {
 
   private static final String CATEGORY = "TFVC";
   private static final String USERNAME_PROPERTY_KEY = "sonar.tfvc.username";
   private static final String PASSWORD_PROPERTY_KEY = "sonar.tfvc.password.secured";
   private static final String COLLECTIONURI_PROPERTY_KEY = "sonar.tfvc.collectionuri";
   private static final String PAT_PROPERTY_KEY = "sonar.tfvc.pat.secured";
-  private final Settings settings;
+  private final Configuration settings;
 
-  public TfsConfiguration(Settings settings) {
+  public TfsConfiguration(Configuration settings) {
     this.settings = settings;
   }
 
@@ -73,19 +73,19 @@ public class TfsConfiguration implements BatchComponent {
   }
 
   public String username() {
-    return Strings.nullToEmpty(settings.getString(USERNAME_PROPERTY_KEY));
+    return settings.get(USERNAME_PROPERTY_KEY).orElse("");
   }
 
   public String password() {
-    return Strings.nullToEmpty(settings.getString(PASSWORD_PROPERTY_KEY));
+    return settings.get(PASSWORD_PROPERTY_KEY).orElse("");
   }
 
   public String collectionUri() {
-    return Strings.nullToEmpty(settings.getString(COLLECTIONURI_PROPERTY_KEY));
+    return settings.get(COLLECTIONURI_PROPERTY_KEY).orElse("");
   }
 
   public String pat() {
-    return Strings.nullToEmpty(settings.getString(PAT_PROPERTY_KEY));
+    return settings.get(PAT_PROPERTY_KEY).orElse("");
   }
 
 }

--- a/sonar-scm-tfvc-plugin/src/main/java/org/sonar/plugins/scm/tfs/TfsPlugin.java
+++ b/sonar-scm-tfvc-plugin/src/main/java/org/sonar/plugins/scm/tfs/TfsPlugin.java
@@ -6,25 +6,18 @@
  */
 package org.sonar.plugins.scm.tfs;
 
-import com.google.common.collect.ImmutableList;
-import org.sonar.api.SonarPlugin;
+import org.sonar.api.Plugin;
 
-import java.util.List;
-
-public class TfsPlugin extends SonarPlugin {
+public class TfsPlugin implements Plugin {
 
   @Override
-  public List getExtensions() {
-    ImmutableList.Builder builder = ImmutableList.builder();
-
-    builder.add(
+  public void define(Context context) {
+    context.addExtensions(
       TfsScmProvider.class,
       TfsBlameCommand.class,
       TfsConfiguration.class);
 
-    builder.addAll(TfsConfiguration.getProperties());
-
-    return builder.build();
+    context.addExtensions(TfsConfiguration.getProperties());
   }
 
 }

--- a/sonar-scm-tfvc-plugin/src/test/java/org/sonar/plugins/scm/tfs/TfsBlameCommandTest.java
+++ b/sonar-scm-tfvc-plugin/src/test/java/org/sonar/plugins/scm/tfs/TfsBlameCommandTest.java
@@ -20,6 +20,7 @@ import org.mockito.Mockito;
 import org.slf4j.LoggerFactory;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.fs.internal.DefaultInputFile;
+import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 import org.sonar.api.batch.scm.BlameCommand.BlameInput;
 import org.sonar.api.batch.scm.BlameCommand.BlameOutput;
 import org.sonar.api.batch.scm.BlameLine;
@@ -57,7 +58,9 @@ public class TfsBlameCommandTest {
     TfsBlameCommand command = new TfsBlameCommand(conf, executable);
 
     File file = new File("src/test/resources/ok.txt");
-    DefaultInputFile inputFile = new DefaultInputFile("ok", "ok.txt").setAbsolutePath(file.getAbsolutePath());
+    DefaultInputFile inputFile = new TestInputFileBuilder("ok", "ok.txt")
+            .setModuleBaseDir(file.toPath().getParent())
+            .build();
 
     BlameInput input = mock(BlameInput.class);
     when(input.filesToBlame()).thenReturn(Arrays.<InputFile>asList(inputFile));
@@ -81,8 +84,10 @@ public class TfsBlameCommandTest {
     TfsBlameCommand command = new TfsBlameCommand(conf, executable);
 
     File file = new File("src/test/resources/ok.txt");
-    DefaultInputFile inputFile = new DefaultInputFile("ok", "ok.txt").setAbsolutePath(file.getAbsolutePath());
-    inputFile.setLines(3);
+    DefaultInputFile inputFile = new TestInputFileBuilder("ok", "ok.txt")
+            .setModuleBaseDir(file.toPath().getParent())
+            .setLines(3)
+            .build();
 
     BlameInput input = mock(BlameInput.class);
     when(input.filesToBlame()).thenReturn(Arrays.<InputFile>asList(inputFile));
@@ -107,7 +112,9 @@ public class TfsBlameCommandTest {
     TfsBlameCommand command = new TfsBlameCommand(conf, executable);
 
     File file = new File("src/test/resources/invalid_output.txt");
-    DefaultInputFile inputFile = new DefaultInputFile("invalid_output", "invalid_output.txt").setAbsolutePath(file.getAbsolutePath());
+    DefaultInputFile inputFile = new TestInputFileBuilder("invalid_output", "invalid_output.txt")
+      .setModuleBaseDir(file.toPath().getParent())
+      .build();
 
     BlameInput input = mock(BlameInput.class);
     when(input.filesToBlame()).thenReturn(Arrays.<InputFile>asList(inputFile));
@@ -126,10 +133,14 @@ public class TfsBlameCommandTest {
     TfsBlameCommand command = new TfsBlameCommand(conf, executable);
 
     File file = new File("src/test/resources/ko_non_existing.txt");
-    DefaultInputFile inputFile = new DefaultInputFile("ko_non_existing", "ko_non_existing.txt").setAbsolutePath(file.getAbsolutePath());
+    DefaultInputFile inputFile = new TestInputFileBuilder("ko_non_existing", "ko_non_existing.txt")
+            .setModuleBaseDir(file.toPath().getParent())
+            .build();
 
     File file2 = new File("src/test/resources/ok.txt");
-    DefaultInputFile inputFile2 = new DefaultInputFile("ok", "ok.txt").setAbsolutePath(file2.getAbsolutePath());
+    DefaultInputFile inputFile2 = new TestInputFileBuilder("ok", "ok.txt")
+            .setModuleBaseDir(file2.toPath().getParent())
+            .build();
 
 
     BlameInput input = mock(BlameInput.class);
@@ -152,7 +163,9 @@ public class TfsBlameCommandTest {
     TfsBlameCommand command = new TfsBlameCommand(conf, executable);
 
     File file = new File("src/test/resources/ko_non_existing.txt");
-    DefaultInputFile inputFile = new DefaultInputFile("ko_non_existing", "ko_non_existing.txt").setAbsolutePath(file.getAbsolutePath());
+    DefaultInputFile inputFile = new TestInputFileBuilder("ko_non_existing", "ko_non_existing.txt")
+            .setModuleBaseDir(file.toPath().getParent())
+            .build();
 
 
     BlameInput input = mock(BlameInput.class);

--- a/sonar-scm-tfvc-plugin/src/test/java/org/sonar/plugins/scm/tfs/TfsConfigurationTest.java
+++ b/sonar-scm-tfvc-plugin/src/test/java/org/sonar/plugins/scm/tfs/TfsConfigurationTest.java
@@ -8,7 +8,7 @@ package org.sonar.plugins.scm.tfs;
 
 import org.junit.Test;
 import org.sonar.api.config.PropertyDefinitions;
-import org.sonar.api.config.Settings;
+import org.sonar.api.config.internal.MapSettings;
 
 import static org.fest.assertions.Assertions.assertThat;
 
@@ -16,8 +16,8 @@ public class TfsConfigurationTest {
 
   @Test
   public void sanityCheck() {
-    Settings settings = new Settings(new PropertyDefinitions(TfsConfiguration.getProperties()));
-    TfsConfiguration config = new TfsConfiguration(settings);
+	MapSettings settings = new MapSettings(new PropertyDefinitions(TfsConfiguration.getProperties()));
+    TfsConfiguration config = new TfsConfiguration(settings.asConfig());
 
     assertThat(config.username()).isEmpty();
     assertThat(config.password()).isEmpty();

--- a/sonar-scm-tfvc-plugin/src/test/java/org/sonar/plugins/scm/tfs/TfsPluginTest.java
+++ b/sonar-scm-tfvc-plugin/src/test/java/org/sonar/plugins/scm/tfs/TfsPluginTest.java
@@ -7,6 +7,7 @@
 package org.sonar.plugins.scm.tfs;
 
 import org.junit.Test;
+import org.sonar.api.Plugin.Context;
 
 import static org.fest.assertions.Assertions.assertThat;
 
@@ -14,7 +15,9 @@ public class TfsPluginTest {
 
   @Test
   public void getExtensions() {
-    assertThat(new TfsPlugin().getExtensions()).hasSize(3 + TfsConfiguration.getProperties().size());
+    Context cntx = new Context(null);
+    new TfsPlugin().define(cntx);
+    assertThat(cntx.getExtensions()).hasSize(3 + TfsConfiguration.getProperties().size());
   }
 
 }


### PR DESCRIPTION
Hei.

An attempt to make the plugin compatible with 7.3 https://github.com/SonarQubeCommunity/sonar-scm-tfvc/issues/41

I'm not Java developer so be aware...

There's still usage of depreciated InputFile.absolutePath() but replacing it with Paths.get(inputFile.uri()).toAbsolutePath() didn't seem to be much better and inputFile.uri() didn't work out (easily)