### PR TITLE
check CollectionUri to prevent from missing blame information

### DIFF
--- a/sonar-scm-tfvc-plugin/src/main/java/org/sonar/plugins/scm/tfs/TfsBlameCommand.java
+++ b/sonar-scm-tfvc-plugin/src/main/java/org/sonar/plugins/scm/tfs/TfsBlameCommand.java
@@ -45,7 +45,9 @@ public class TfsBlameCommand extends BlameCommand {
 
   @VisibleForTesting
   public TfsBlameCommand(TfsConfiguration conf, File executable) {
+    logDebug("started blaming with executable %s", executable.getAbsolutePath());
     if (conf.collectionUri().isEmpty()) {
+      logError("Missing configuration for CollectionUri");
       throw new IllegalArgumentException("Missing configuration for CollectionUri.");
     }
 

--- a/sonar-scm-tfvc-plugin/src/main/java/org/sonar/plugins/scm/tfs/TfsBlameCommand.java
+++ b/sonar-scm-tfvc-plugin/src/main/java/org/sonar/plugins/scm/tfs/TfsBlameCommand.java
@@ -45,6 +45,10 @@ public class TfsBlameCommand extends BlameCommand {
 
   @VisibleForTesting
   public TfsBlameCommand(TfsConfiguration conf, File executable) {
+    if (conf.collectionUri().isEmpty()) {
+      throw new IllegalArgumentException("Missing configuration for CollectionUri.");
+    }
+
     this.conf = conf;
     this.executable = executable;
   }

--- a/sonar-scm-tfvc-plugin/src/test/resources/ko_0_lines.txt
+++ b/sonar-scm-tfvc-plugin/src/test/resources/ko_0_lines.txt
@@ -1,3 +1,0 @@
-0
-26274 SND\DinSoft_cp 1430736199000 hello,
-26275 SND\DinSoft_cp 1430736200000 world!


### PR DESCRIPTION
If collection URL was not configured, the problem was silently ignored. The files just not got blame information.
With this changed the analysis will be stopped.