### PR TITLE
Fix regression on configuration

### DIFF
--- a/sonar-scm-tfvc-plugin/src/main/java/org/sonar/plugins/scm/tfs/TfsBlameCommand.java
+++ b/sonar-scm-tfvc-plugin/src/main/java/org/sonar/plugins/scm/tfs/TfsBlameCommand.java
@@ -47,8 +47,7 @@ public class TfsBlameCommand extends BlameCommand {
   public TfsBlameCommand(TfsConfiguration conf, File executable) {
     logDebug("started blaming with executable %s", executable.getAbsolutePath());
     if (conf.collectionUri().isEmpty()) {
-      logError("Missing configuration for CollectionUri");
-      throw new IllegalArgumentException("Missing configuration for CollectionUri.");
+      logWarning("Missing configuration for CollectionUri. The project may not receive blame information.");
     }
 
     this.conf = conf;
@@ -183,6 +182,11 @@ public class TfsBlameCommand extends BlameCommand {
   private static void logDebug(String message, Object... arguments) {
     String fullMessage = String.format(message, arguments);
     LOG.debug(LOG_FORMAT, LOG_PREFIX, fullMessage);
+  }
+
+  private static void logWarning(String message, Object... arguments) {
+    String fullMessage = String.format(message, arguments);
+    LOG.warn(LOG_FORMAT, LOG_PREFIX, fullMessage);
   }
 
   private static void logError(String message, Object... arguments) {

--- a/sonar-scm-tfvc-plugin/src/test/java/org/sonar/plugins/scm/tfs/TfsBlameCommandTest.java
+++ b/sonar-scm-tfvc-plugin/src/test/java/org/sonar/plugins/scm/tfs/TfsBlameCommandTest.java
@@ -53,12 +53,16 @@ public class TfsBlameCommandTest {
     getRootLogger().detachAppender(appender);
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void init_missingCollectionUri_exceptionThrown() {
+  @Test
+  public void init_missingCollectionUri_noExceptionThrown() {
     File executable = new File("src/test/resources/fake.bat");
     when(conf.collectionUri()).thenReturn("");
 
-    new TfsBlameCommand(conf, executable);
+    TfsBlameCommand command = new TfsBlameCommand(conf, executable);
+    assertThat(command).isNotNull();
+    assertThat(appender.getErrorEvents()).isEmpty();
+    assertThat(appender.getWarningEvents()).containsExactly(
+        "SCM-TFVC: Missing configuration for CollectionUri. The project may not receive blame information.");
   }
 
   @Test

--- a/sonar-scm-tfvc-plugin/src/test/java/org/sonar/plugins/scm/tfs/helpers/TestAppender.java
+++ b/sonar-scm-tfvc-plugin/src/test/java/org/sonar/plugins/scm/tfs/helpers/TestAppender.java
@@ -16,15 +16,24 @@ public class TestAppender extends ConsoleAppender<ILoggingEvent> {
 
   private List<String> errorEvents = new ArrayList<>();
 
+  private List<String> warningEvents = new ArrayList<>();
+
   @Override
   public void doAppend(ILoggingEvent event) {
     if (event.getLevel() == Level.ERROR) {
       errorEvents.add(event.getFormattedMessage());
     }
+    if (event.getLevel() == Level.WARN) {
+      warningEvents.add(event.getFormattedMessage());
+    }
   }
 
   public List<String> getErrorEvents() {
     return errorEvents;
+  }
+
+  public List<String> getWarningEvents() {
+    return warningEvents;
   }
 
 }


### PR DESCRIPTION
If SonarQube server is used for TFVC and other version control systems, the plugin will be called without sufficient configuration.
Now an explicit warning is written instead of aborting the analysis.

Fixes regression in #58 and changes behavior of #53.