### PR TITLE
Revert update of Microsoft.TeamFoundationServer.ExtendedClient back to version 16.170.0

### DIFF
--- a/SonarTfsAnnotate/SonarTfsAnnotate.csproj
+++ b/SonarTfsAnnotate/SonarTfsAnnotate.csproj
@@ -65,7 +65,7 @@
       <Version>5.2.8</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.TeamFoundationServer.ExtendedClient">
-      <Version>19.225.1</Version>
+      <Version>16.170.0</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>13.0.2</Version>


### PR DESCRIPTION
In #112 this package was updated accidentally.